### PR TITLE
fixed typo in include

### DIFF
--- a/src/ClipBoard.cpp
+++ b/src/ClipBoard.cpp
@@ -18,7 +18,7 @@
 * See https://github.com/Akira-Hayasaka/ofxGLEditor for more info.
 */
 
-#include "Clipboard.h"
+#include "ClipBoard.h"
 
 string ClipBoard::getText() {
   


### PR DESCRIPTION
was Clipboard.h however the file is named ClipBoard.h
